### PR TITLE
Added a new merger timescale model

### DIFF
--- a/include/galaxy_mergers.h
+++ b/include/galaxy_mergers.h
@@ -70,6 +70,13 @@ class GalaxyMergerParameters {
 		float merger_ratio_dissipation = 0;
 		double fgas_dissipation = 0;
 
+		enum GalaxyMergerTimescaleModel{
+			LACEY93 = 0,
+			POULTON20
+		};
+
+		GalaxyMergerTimescaleModel model = POULTON20;
+
 };
 
 
@@ -79,6 +86,7 @@ class GalaxyMergers{
 public:
 	GalaxyMergers(GalaxyMergerParameters parameters,
 			CosmologyPtr cosmology,
+			CosmologicalParameters cosmo_params,
 			const ExecutionParameters &execparams,
 			SimulationParameters simparams,
 			DarkMatterHalosPtr darkmatterhalo,
@@ -143,6 +151,7 @@ public:
 private:
 	GalaxyMergerParameters parameters;
 	std::shared_ptr<Cosmology> cosmology;
+	CosmologicalParameters cosmo_params;
 	SimulationParameters simparams;
 	DarkMatterHalosPtr darkmatterhalo;
 	std::shared_ptr<BasicPhysicalModel> physicalmodel;

--- a/include/subhalo.h
+++ b/include/subhalo.h
@@ -206,7 +206,7 @@ public:
 	float Mvir = 0;
 	/// gas mass in the subhalo [Msun/h]. This is different than 0 if the input simulation is a hydrodynamical simulation.
 	float Mgas = 0;
-	/// numver of dark matter particles in the halo
+	/// number of dark matter particles in the halo
 	int Npart = 0;
 	/// angular momentum of subhalo [Msun/h km/s Mpc/h]
 	xyz<float> L {0, 0, 0};

--- a/include/subhalo.h
+++ b/include/subhalo.h
@@ -206,6 +206,8 @@ public:
 	float Mvir = 0;
 	/// gas mass in the subhalo [Msun/h]. This is different than 0 if the input simulation is a hydrodynamical simulation.
 	float Mgas = 0;
+	/// numver of dark matter particles in the halo
+	int Npart = 0;
 	/// angular momentum of subhalo [Msun/h km/s Mpc/h]
 	xyz<float> L {0, 0, 0};
 	/// maximum circular velocity of the subhalo [km/s]

--- a/sample.cfg
+++ b/sample.cfg
@@ -121,6 +121,7 @@ cgal = 0.49
 tau_delay = 0.1
 fgas_dissipation = 1
 merger_ratio_dissipation = 0.3
+merger_timescale_model = poulton20
 
 [disk_instability]
 stable = 0.8

--- a/src/merger_tree_reader.cpp
+++ b/src/merger_tree_reader.cpp
@@ -106,8 +106,9 @@ const std::vector<SubhaloPtr> SURFSReader::read_subhalos(unsigned int batch)
 	std::vector<float> position = batch_file.read_dataset_v_2<float>("haloTrees/position");
 	std::vector<float> velocity = batch_file.read_dataset_v_2<float>("haloTrees/velocity");
 
-	//Read mass, circular velocity and angular momentum.
+	//Read mass, npart, circular velocity and angular momentum.
 	std::vector<float> Mvir = batch_file.read_dataset_v<float>("haloTrees/nodeMass");
+	std::vector<int> Npart = batch_file.read_dataset_v<int>("haloTrees/particleNumber");
 	std::vector<float> Vcirc = batch_file.read_dataset_v<float>("haloTrees/maximumCircularVelocity");
 	std::vector<float> L = batch_file.read_dataset_v_2<float>("haloTrees/angularMomentum");
 
@@ -195,6 +196,9 @@ const std::vector<SubhaloPtr> SURFSReader::read_subhalos(unsigned int batch)
 		if(simulation_params.hydrorun){
 			subhalo->Mgas = Mgas[i];
 		}
+
+		//Assign npart
+		subhalo->Npart = Npart[i];
 
 		//Assign position
 		subhalo->position.x = position[3 * i];

--- a/src/shark_runner.cpp
+++ b/src/shark_runner.cpp
@@ -232,7 +232,7 @@ void SharkRunner::impl::create_per_thread_objects()
 	for(unsigned int i = 0; i != threads; i++) {
 		auto physical_model = std::make_shared<BasicPhysicalModel>(exec_params.ode_solver_precision, gas_cooling, stellar_feedback, star_formation, *agnfeedback,
 				recycling_params, gas_cooling_params, agn_params);
-		GalaxyMergers galaxy_mergers(merger_parameters, cosmology, exec_params, simulation_params, dark_matter_halos, physical_model, agnfeedback);
+		GalaxyMergers galaxy_mergers(merger_parameters, cosmology, cosmo_params, exec_params, simulation_params, dark_matter_halos, physical_model, agnfeedback);
 		DiskInstability disk_instability(disk_instability_params, merger_parameters, simulation_params, dark_matter_halos, physical_model, agnfeedback);
 		thread_objects.emplace_back(std::move(physical_model), std::move(galaxy_mergers), std::move(disk_instability));
 	}


### PR DESCRIPTION
The new model is to be presented in poulton et al., in prep.
There are now two possible merger timescale models in shark,
these can be set from the merger_timescale_model config option,
where the possible options are 'lacey93' (old model) or
'poulton20' (new model).