### PR TITLE
Change to black hole growth during starbursts

### DIFF
--- a/src/disk_instability.cpp
+++ b/src/disk_instability.cpp
@@ -188,9 +188,11 @@ void DiskInstability::create_starburst(SubhaloPtr &subhalo, GalaxyPtr &galaxy, d
 		// Define accretion rate.
 		galaxy->smbh.macc_sb = delta_mbh/tdyn;
 
-		// Grow SMBH.
-		galaxy->smbh.mass += delta_mbh;
-		galaxy->smbh.mass_metals += delta_mzbh;
+		// Check if SMBH exists in this galaxy, then grow it.
+		if(galaxy->smbh.mass != 0){
+			galaxy->smbh.mass += delta_mbh;
+			galaxy->smbh.mass_metals += delta_mzbh;
+		}
 
 		// Reduce gas available for star formation due to black hole growth.
 		galaxy->bulge_gas.mass -= delta_mbh;

--- a/src/galaxy_mergers.cpp
+++ b/src/galaxy_mergers.cpp
@@ -540,8 +540,11 @@ void GalaxyMergers::create_starbursts(HaloPtr &halo, double z, double delta_t){
 				physicalmodel->evolve_galaxy_starburst(*subhalo, *galaxy, z, delta_t, true);
 
 				// Grow SMBH after starbursts, as during it we need a realistical measurement of Ledd the BH had before the starburst.
-				galaxy->smbh.mass += delta_mbh;
-				galaxy->smbh.mass_metals += delta_mzbh;
+				// Check if SMBH exists in this galaxy, then grow it.
+				if(galaxy->smbh.mass != 0){
+					galaxy->smbh.mass += delta_mbh;
+					galaxy->smbh.mass_metals += delta_mzbh;
+				}
 
 				// Check for small gas reservoirs left in the bulge, in case mass is small, transfer to disk.
 				if(galaxy->bulge_gas.mass > 0 && galaxy->bulge_gas.mass < parameters.mass_min){


### PR DESCRIPTION
The formula used to calculate black hole growth during starbursts does not depend on the mass of the black hole, meaning that galaxies with no black hole (in which case m_bh = 0) can spontaneously gain a low-mass black hole. These black holes are well below the seeding mass, and are ignored when plotting, so I think it would be better to not allow them to be created in the first place. This is done by checking if a galaxy actually has a black hole first, before then calculating its growth during starbursts as before.