### PR TITLE
Mass swapping fixes

### DIFF
--- a/include/agn_feedback.h
+++ b/include/agn_feedback.h
@@ -35,6 +35,7 @@
 #include "options.h"
 #include "recycling.h"
 #include "subhalo.h"
+#include "dark_matter_halos.h"
 
 namespace shark {
 
@@ -100,7 +101,8 @@ public:
 class AGNFeedback {
 
 public:
-	AGNFeedback(const AGNFeedbackParameters &parameters, CosmologyPtr cosmology, RecyclingParameters recycle_params, ExecutionParameters exec_params);
+  AGNFeedback(const AGNFeedbackParameters &parameters, CosmologyPtr cosmology, RecyclingParameters recycle_params, ExecutionParameters exec_params,
+	      DarkMatterHaloParameters dark_matter_params);
 
 	/**
 	 * All input quantities should be in comoving units.
@@ -132,6 +134,7 @@ private:
 	CosmologyPtr cosmology;
 	RecyclingParameters recycle_params;
 	ExecutionParameters exec_params;
+        DarkMatterHaloParameters dark_matter_params;
 
 	std::uniform_real_distribution<double> distribution;
 

--- a/include/gas_cooling.h
+++ b/include/gas_cooling.h
@@ -103,6 +103,7 @@ public:
 			ReionisationPtr reionisation,
 			CosmologyPtr cosmology,
 			AGNFeedbackPtr agnfeedback,
+		        DarkMatterHaloParameters dark_matter_params,
 			DarkMatterHalosPtr darkmatterhalos,
 			ReincorporationPtr reincorporation,
 			EnvironmentPtr environment);
@@ -124,6 +125,7 @@ private:
 	ReionisationPtr reionisation;
 	CosmologyPtr cosmology;
 	AGNFeedbackPtr agnfeedback;
+        DarkMatterHaloParameters dark_matter_params;
 	DarkMatterHalosPtr darkmatterhalos;
 	ReincorporationPtr reincorporation;
 	EnvironmentPtr environment;

--- a/include/tree_builder.h
+++ b/include/tree_builder.h
@@ -63,8 +63,8 @@ private:
 	void ensure_trees_are_self_contained(const std::vector<MergerTreePtr> &trees) const;
 	void ensure_halo_mass_growth(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params);
 	void spin_interpolated_halos(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params);
-	void define_central_subhalos(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params, DarkMatterHaloParameters &dark_matter_params);
-	SubhaloPtr define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhalo);
+        void define_central_subhalos(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params, DarkMatterHaloParameters &dark_matter_params, const DarkMatterHalosPtr &darkmatterhalos);
+        SubhaloPtr define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhalo);
 	void define_accretion_rate_from_dm(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params, GasCoolingParameters &gas_cooling_params, Cosmology &cosmology, TotalBaryon &AllBaryons);
 	void remove_satellite(HaloPtr &halo, SubhaloPtr &subhalo);
  	void define_ages_halos(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params, const DarkMatterHalosPtr &darkmatterhalos);

--- a/src/agn_feedback.cpp
+++ b/src/agn_feedback.cpp
@@ -153,7 +153,7 @@ void AGNFeedback::plant_seed_smbh(Subhalo &subhalo){
 		if(subhalo.subhalo_type == Subhalo::CENTRAL){
 			mvir = subhalo.host_halo->Mvir;
 		}
-		else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall!=0){
+		else if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 			mvir = subhalo.Mvir_infall;
 		}
 		else{

--- a/src/dark_matter_halos.cpp
+++ b/src/dark_matter_halos.cpp
@@ -148,7 +148,7 @@ double DarkMatterHalos::subhalo_dynamical_time (Subhalo &subhalo, double z){
 		r = halo_virial_radius(subhalo.host_halo->Mvir, z);
 		v = subhalo.Vvir;
 	}
-	else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+	else if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 		r = subhalo.rvir_infall;
 		v = subhalo.Vvir_infall;
 	}
@@ -177,7 +177,7 @@ float DarkMatterHalos::halo_lambda (const Subhalo &subhalo, float m, double z, d
 	double H0 = cosmology->hubble_parameter(z);
 	double lambda = subhalo.L.norm() / m * 1.5234153 / std::pow(constants::G * m, 0.666) * std::pow(H0,0.33);
 
-	if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+	if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 	        lambda = subhalo.L_infall.norm() / m * 1.5234153 / std::pow(constants::G * m, 0.666) * std::pow(H0,0.33);
 	}
 	else{
@@ -230,7 +230,7 @@ double DarkMatterHalos::disk_size_theory (Subhalo &subhalo, double z){
 		        Rvir = halo_virial_radius(subhalo.host_halo->Mvir, z);
 			lambda = subhalo.host_halo->lambda;
 		}
-		else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+		else if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 		        Rvir = subhalo.rvir_infall;
 			lambda = subhalo.lambda_infall;
 		}
@@ -313,7 +313,7 @@ void DarkMatterHalos::cooling_gas_sAM(Subhalo &subhalo, double z){
 		        subhalo.cold_halo_gas.sAM = constants::SQRT2 * std::pow(constants::G,0.66) *
 			                                            subhalo.host_halo->lambda * std::pow(subhalo.host_halo->Mvir,0.66) / std::pow(H0,0.33);
 		}
-		else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+		else if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 		        // Define Mvir at infall for satellite
 		        subhalo.cold_halo_gas.sAM = constants::SQRT2 * std::pow(constants::G,0.66) *
 			                                            subhalo.lambda_infall * std::pow(subhalo.Mvir_infall,0.66) / std::pow(H0,0.33);

--- a/src/dark_matter_halos.cpp
+++ b/src/dark_matter_halos.cpp
@@ -375,7 +375,7 @@ float DarkMatterHalos::enclosed_total_mass(const Subhalo &subhalo, double z, flo
 		        // Define Mvir, Rvir from host halo
 		        mvir = subhalo.host_halo->Mvir;
 			rvir = halo_virial_radius(subhalo.host_halo->Mvir, z);
-			concentration = subhalo.host_halo->concentration_infall;
+			concentration = subhalo.host_halo->concentration;
 		}
 	        else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
 		        galaxy = subhalo.type1_galaxy();
@@ -393,7 +393,7 @@ float DarkMatterHalos::enclosed_total_mass(const Subhalo &subhalo, double z, flo
 		        // for type1 galaxies, we use the information at infall
 		        mvir = subhalo.Mvir;
 			rvir = halo_virial_radius(subhalo.Mvir, z);
-			concentration = subhalo.concentration_infall;
+			concentration = subhalo.concentration;
 		}
 	}
 	else{

--- a/src/dark_matter_halos.cpp
+++ b/src/dark_matter_halos.cpp
@@ -369,17 +369,40 @@ float DarkMatterHalos::enclosed_total_mass(const Subhalo &subhalo, double z, flo
 	double rvir = 0;
 	double concentration = 0;
 
-	galaxy = subhalo.type1_galaxy();
-
 	if(	params.apply_fix_to_mass_swapping_events){
-		// Define infall Mvir, Rvir for satellites
-		// since this is to compute the ram pressure stripping
-		// for type1 galaxies, we use the information at infall
-		mvir = subhalo.Mvir_infall;
-		rvir = halo_virial_radius(subhalo.Mvir_infall, subhalo.infall_t);
-		concentration = subhalo.concentration_infall;
+	        if(subhalo.subhalo_type == Subhalo::CENTRAL){
+		        galaxy = subhalo.central_galaxy();
+		        // Define Mvir, Rvir from host halo
+		        mvir = subhalo.host_halo->Mvir;
+			rvir = halo_virial_radius(subhalo.host_halo->Mvir, z);
+			concentration = subhalo.host_halo->concentration_infall;
+		}
+	        else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+		        galaxy = subhalo.type1_galaxy();
+		        // Define infall Mvir, Rvir for satellites
+		        // since this is to compute the ram pressure stripping
+		        // for type1 galaxies, we use the information at infall
+		        mvir = subhalo.Mvir_infall;
+			rvir = halo_virial_radius(subhalo.Mvir_infall, subhalo.infall_t);
+			concentration = subhalo.concentration_infall;
+		}
+		else{
+		        galaxy = subhalo.type1_galaxy();
+		        // Define current  Mvir, Rvir for satellites born as satellites
+		        // since this is to compute the ram pressure stripping
+		        // for type1 galaxies, we use the information at infall
+		        mvir = subhalo.Mvir;
+			rvir = halo_virial_radius(subhalo.Mvir, z);
+			concentration = subhalo.concentration_infall;
+		}
 	}
 	else{
+	        if(subhalo.subhalo_type == Subhalo::CENTRAL){
+		        galaxy = subhalo.central_galaxy();
+		}
+	        else{
+		        galaxy = subhalo.type1_galaxy();
+		}
 		mvir = subhalo.Mvir;
 		rvir = halo_virial_radius(subhalo.Mvir, z);
 		concentration = subhalo.concentration;

--- a/src/disk_instability.cpp
+++ b/src/disk_instability.cpp
@@ -188,7 +188,7 @@ void DiskInstability::create_starburst(SubhaloPtr &subhalo, Galaxy &galaxy, doub
 		// grow the BH only if its mass is already >  0 (so the BH has been seeded).
 		if(galaxy.smbh.mass > 0){
 			delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir, tdyn, galaxy);
-			if(subhalo->subhalo_type == Subhalo::SATELLITE && !subhalo->ascendants.empty() &&
+			if(subhalo->subhalo_type == Subhalo::SATELLITE && subhalo->Vvir_infall != 0 &&
 					darkmatterparams.apply_fix_to_mass_swapping_events){
 				// at infall for subhalos that become satellite
 				delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir_infall, tdyn, galaxy);

--- a/src/disk_instability.cpp
+++ b/src/disk_instability.cpp
@@ -182,7 +182,7 @@ void DiskInstability::create_starburst(SubhaloPtr &subhalo, Galaxy &galaxy, doub
 		double tdyn = agnfeedback->smbh_accretion_timescale(galaxy, z);
 		double delta_mbh = 0;
 		double delta_mzbh = 0;
-		if(subhalo->subhalo_type == Subhalo::SATELLITE && subhalo->Vvir_infall != 0){
+		if(subhalo->subhalo_type == Subhalo::SATELLITE && !subhalo->ascendants.empty()){
 		        // at infall for subhalos that become satellite
 		        delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir_infall, tdyn, galaxy);
 		}

--- a/src/evolve_halos.cpp
+++ b/src/evolve_halos.cpp
@@ -78,6 +78,7 @@ void adjust_main_galaxy(const SubhaloPtr &parent, const SubhaloPtr &descendant)
 		main_galaxy->concentration_type2 = parent->concentration;
 		main_galaxy->msubhalo_type2 = parent->Mvir;
 		main_galaxy->lambda_type2 = parent->lambda;
+		main_galaxy->vvir_type2 = parent->Vvir;
 	}
 
 	// If main_galaxy is type 1 and the ram pressure stripping radius has not been defined, then define it to be equal to the descendant subhalo rvir_infall.

--- a/src/galaxy_creator.cpp
+++ b/src/galaxy_creator.cpp
@@ -91,7 +91,7 @@ bool GalaxyCreator::create_galaxies(const HaloPtr &halo, double z, Galaxy::id_t 
 	}
 
 	auto &galaxy = central_subhalo->emplace_galaxy(galaxy_id);
-	galaxy.vmax = central_subhalo->Vcirc;
+	galaxy.vmax = central_subhalo->Vvir;
 
 	//If the input simulation is a hydro simulation, then use the input gas mass.
 	if(sim_params.hydrorun){

--- a/src/galaxy_mergers.cpp
+++ b/src/galaxy_mergers.cpp
@@ -597,7 +597,7 @@ void GalaxyMergers::create_starbursts(HaloPtr &halo, double z, double delta_t){
 					double tdyn = agnfeedback->smbh_accretion_timescale(galaxy, z);
 
 					delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir, tdyn, galaxy);
-					if(subhalo->subhalo_type == Subhalo::SATELLITE && !subhalo->ascendants.empty() &&
+					if(subhalo->subhalo_type == Subhalo::SATELLITE && subhalo->Vvir_infall != 0 &&
 							dark_matter_params.apply_fix_to_mass_swapping_events){
 						// at infall for subhalos that become satellite
 						delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir_infall, tdyn, galaxy);

--- a/src/galaxy_mergers.cpp
+++ b/src/galaxy_mergers.cpp
@@ -592,7 +592,7 @@ void GalaxyMergers::create_starbursts(HaloPtr &halo, double z, double delta_t){
 				double delta_mbh = 0;
 				double delta_mzbh = 0;
 
-				if(subhalo->subhalo_type == Subhalo::SATELLITE && subhalo->Vvir_infall != 0){
+				if(subhalo->subhalo_type == Subhalo::SATELLITE && !subhalo->ascendants.empty()){
 				        // at infall for subhalos that become satellite
 				        delta_mbh = agnfeedback->smbh_growth_starburst(galaxy.bulge_gas.mass, subhalo->Vvir_infall, tdyn, galaxy);
 				}

--- a/src/gas_cooling.cpp
+++ b/src/gas_cooling.cpp
@@ -359,7 +359,7 @@ double GasCooling::cooling_rate(Subhalo &subhalo, Galaxy &galaxy, double z, doub
 	if(subhalo.subhalo_type == Subhalo::CENTRAL){
 	         subhalo.hot_halo_gas.sAM = subhalo.L.norm() / subhalo.host_halo->Mvir;
 	}
-	else if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Mvir_infall != 0){
+	else if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 	         subhalo.hot_halo_gas.sAM = subhalo.L_infall.norm() / subhalo.Mvir_infall;
 	}
 	else{
@@ -384,7 +384,7 @@ double GasCooling::cooling_rate(Subhalo &subhalo, Galaxy &galaxy, double z, doub
 	double fhot = mhot / subhalo.Mvir;
 
 	// If subhalo is a satellite, then use the virial velocity the subhalo had at infall.
-	if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Vvir_infall != 0){
+	if(subhalo.subhalo_type == Subhalo::SATELLITE && !subhalo.ascendants.empty()){
 	        vvir = subhalo.Vvir_infall;
 		fhot = mhot / subhalo.Mvir_infall;
 	}
@@ -414,7 +414,7 @@ double GasCooling::cooling_rate(Subhalo &subhalo, Galaxy &galaxy, double z, doub
 	if(subhalo.subhalo_type == Subhalo::CENTRAL){
 		Rvir = cosmology->comoving_to_physical_size(darkmatterhalos->halo_virial_radius(halo->Mvir, z), z);//physical Mpc
 	}
-	else if (subhalo.subhalo_type == Subhalo::CENTRAL && subhalo.rvir_infall != 0){
+	else if (subhalo.subhalo_type == Subhalo::CENTRAL && !subhalo.ascendants.empty()){
 		//If subhalo is a satellite, then adopt virial radius at infall.
 		Rvir = cosmology->comoving_to_physical_size(subhalo.rvir_infall, z);//physical Mpc
 	}

--- a/src/gas_cooling.cpp
+++ b/src/gas_cooling.cpp
@@ -392,6 +392,7 @@ double GasCooling::cooling_rate(Subhalo &subhalo, Galaxy &galaxy, double z, doub
 	if(subhalo.subhalo_type == Subhalo::SATELLITE && subhalo.Vvir_infall != 0 &&
 	               dark_matter_params.apply_fix_to_mass_swapping_events){
 		vvir = subhalo.Vvir_infall;
+		fhot = mhot / subhalo.Mvir_infall;
 	}
 
 	double zhot = 0;

--- a/src/merger_tree_reader.cpp
+++ b/src/merger_tree_reader.cpp
@@ -145,6 +145,7 @@ const std::vector<SubhaloPtr> SURFSReader::read_subhalos(unsigned int batch)
 	        const auto fname_transients = get_transients_filename(batch);
 		hdf5::Reader batch_transients(fname_transients);
 		transientsIndex = batch_transients.read_dataset_v<Subhalo::id_t>("nodeIndex");
+		//		transientsHostIndex = batch_transients.read_dataset_v<Subhalo::id_t>("hostIndex");
 	}
 	  
 	auto n_subhalos = Mvir.size();
@@ -307,6 +308,10 @@ const std::vector<HaloPtr> SURFSReader::read_halos(unsigned int batch)
 		}
 		subhalo->host_halo = halo;
 		halo->add_subhalo(std::move(subhalo));
+//		if (!transients_prefix.empty()){
+//			// create flag to indicate this halo is transient
+//		        halo->transient = std::find(std::begin(transientsHostIndex), std::end(transientsHostIndex), hostIndex[i]) != std::end(transientsHostIndex);
+//		}
 	}
 	subhalos.clear();
 
@@ -315,14 +320,14 @@ const std::vector<HaloPtr> SURFSReader::read_halos(unsigned int batch)
 	os << "This should take another ~" << memory_amount(halos.size() * (sizeof(Halo) + sizeof(HaloPtr))) << " of memory";
 	LOG(info) << os.str();
 
-	// Calculate halos' vvir and concentration
-	t = Timer();
-	omp_dynamic_for(halos, threads, 10000, [&](const HaloPtr &halo, unsigned int thread_idx) {
-		auto z = simulation_params.redshifts[halo->snapshot];
-		halo->Vvir = dark_matter_halos->halo_virial_velocity(halo->Mvir, z);
-		halo->concentration = dark_matter_halos->nfw_concentration(halo->Mvir,z);
-	});
-	LOG(info) << "Calculated Vvir and concentration for new Halos in " << t;
+//	// Calculate halos' vvir and concentration
+//	t = Timer();
+//	omp_dynamic_for(halos, threads, 10000, [&](const HaloPtr &halo, unsigned int thread_idx) {
+//		auto z = simulation_params.redshifts[halo->snapshot];
+//		halo->Vvir = dark_matter_halos->halo_virial_velocity(halo->Mvir, z);
+//		halo->concentration = dark_matter_halos->nfw_concentration(halo->Mvir,z);
+//	});
+//	LOG(info) << "Calculated Vvir and concentration for new Halos in " << t;
 
 	return halos;
 }

--- a/src/shark_runner.cpp
+++ b/src/shark_runner.cpp
@@ -108,7 +108,7 @@ public:
 	    cosmology(make_cosmology(cosmo_params)),
 	    dark_matter_halos(make_dark_matter_halos(dark_matter_halo_params, cosmology, simulation_params, exec_params)),
 	    agn_feedback_params(options),
-	    agn_feedback(make_agn_feedback(agn_feedback_params, cosmology, recycling_params, exec_params)),
+	    agn_feedback(make_agn_feedback(agn_feedback_params, cosmology, recycling_params, exec_params, dark_matter_halo_params)),
 	    writer(make_galaxy_writer(exec_params, cosmo_params, cosmology, dark_matter_halos, simulation_params, agn_feedback_params, agn_feedback)),
 	    simulation(simulation_params, cosmology),
 	    star_formation(star_formation_params, recycling_params, cosmology)
@@ -255,12 +255,12 @@ void SharkRunner::impl::create_per_thread_objects()
 	StellarFeedbackParameters stellar_feedback_params(options);
 	DarkMatterHaloParameters dark_matter_params(options);
 
-	auto agnfeedback = make_agn_feedback(agn_params, cosmology, recycling_params, exec_params);
+	auto agnfeedback = make_agn_feedback(agn_params, cosmology, recycling_params, exec_params, dark_matter_params);
 	auto environment = make_environment(environment_params, dark_matter_halos, cosmology, cosmo_params, simulation_params);
 	auto reionisation = make_reionisation(reio_params);
 	auto reincorporation = make_reincorporation(reinc_params, dark_matter_halos);
 	StellarFeedback stellar_feedback {stellar_feedback_params};
-	GasCooling gas_cooling {gas_cooling_params, star_formation_params, exec_params, reionisation, cosmology, agnfeedback, dark_matter_halos, reincorporation, environment};
+	GasCooling gas_cooling {gas_cooling_params, star_formation_params, exec_params, reionisation, cosmology, agnfeedback, dark_matter_params, dark_matter_halos, reincorporation, environment};
 
 	for(unsigned int i = 0; i != threads; i++) {
 		auto physical_model = std::make_shared<BasicPhysicalModel>(exec_params.ode_solver_precision, gas_cooling, stellar_feedback, star_formation, *agnfeedback,

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -233,8 +233,7 @@ SubhaloPtr TreeBuilder::define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhal
 	subhalo->lambda = darkmatterhalos->halo_lambda(*subhalo, mvir, z, npart);
 	subhalo->Vvir = darkmatterhalos->halo_virial_velocity(mvir, z);
 
-        // it seems redundant when the concentration has been computed before
-	//halo->concentration = subhalo->concentration;
+	halo->concentration = subhalo->concentration;
 	halo->lambda = subhalo->lambda;
 
 	/** If virial velocity of halo (which is calculated from the total mass

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -177,11 +177,11 @@ std::vector<MergerTreePtr> TreeBuilder::build_trees(std::vector<HaloPtr> &halos,
 	LOG(info) << "Defining ages of halos and subhalos";
 	define_ages_halos(trees, sim_params, darkmatterhalos);
 
-	if(dark_matter_params.apply_fix_to_mass_swapping_events){
+	/*if(dark_matter_params.apply_fix_to_mass_swapping_events){
 		// Function to redefine satellite subhalo properties with properties at infall
 		LOG(info) << "Defining velocity, concentration and lambda of satellite subhalos";
 		define_properties_satellite_subhalos(trees, sim_params, darkmatterhalos);
-	}
+	}*/
 
 	return trees;
 }
@@ -595,12 +595,12 @@ void TreeBuilder::define_properties_satellite_subhalos(const std::vector<MergerT
 							double mvir = subhalo->Mvir;
 							double z = sim_params.redshifts[subhalo->snapshot];
 
-//							// in the case of satellite subhalos with a well defined infall mass, we use the virial mass of its host at the time of infall, and the time of infall
-//							// to define other properties.
-//							if(subhalo->Mvir_infall > 0){
-//								mvir = subhalo->Mvir_infall;
-//								z = subhalo->infall_t;
-//							}
+							// in the case of satellite subhalos with a well defined infall mass, we use the virial mass of its host at the time of infall, and the time of infall
+							// to define other properties.
+							if(subhalo->Mvir_infall > 0){
+								mvir = subhalo->Mvir_infall;
+								z = subhalo->infall_t;
+							}
 
 							double npart = mvir/sim_params.particle_mass;
 

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -233,7 +233,8 @@ SubhaloPtr TreeBuilder::define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhal
 	subhalo->lambda = darkmatterhalos->halo_lambda(*subhalo, mvir, z, npart);
 	subhalo->Vvir = darkmatterhalos->halo_virial_velocity(mvir, z);
 
-	halo->concentration = subhalo->concentration;
+        // it seems redundant when the concentration has been computed before
+	//halo->concentration = subhalo->concentration;
 	halo->lambda = subhalo->lambda;
 
 	/** If virial velocity of halo (which is calculated from the total mass

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -222,19 +222,20 @@ SubhaloPtr TreeBuilder::define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhal
 		mvir = halo->Mvir;
 	}
 
-	double z= sim_params.redshifts[subhalo->snapshot];
-	double npart = mvir/sim_params.particle_mass;
+	double z = sim_params.redshifts[subhalo->snapshot];
+	double npart = subhalo->Mvir/sim_params.particle_mass;
 
 	subhalo->concentration = darkmatterhalos->nfw_concentration(mvir, z);
-
+	
 	if (subhalo->concentration < 1) {
-		throw invalid_argument("concentration is <1, cannot continue. Please check input catalogue");
+	        throw invalid_argument("concentration is <1, cannot continue. Please check input catalogue");
 	}
 	subhalo->lambda = darkmatterhalos->halo_lambda(*subhalo, mvir, z, npart);
 	subhalo->Vvir = darkmatterhalos->halo_virial_velocity(mvir, z);
 
-	halo->concentration = subhalo->concentration;
 	halo->lambda = subhalo->lambda;
+	halo->Vvir = darkmatterhalos->halo_virial_velocity(halo->Mvir, z);
+	halo->concentration = darkmatterhalos->nfw_concentration(halo->Mvir,z);
 
 	/** If virial velocity of halo (which is calculated from the total mass
 	and redshift) is smaller than the virial velocity of the central subhalo, which is


### PR DESCRIPTION
Additional fixes to deal with the mass swapping events:
1. Properties at infall should have a non-zero values for the satellite subhalos that aren't born as satellit, since the properties at infall are used for those type of subhalos. For satellite subhalos that are born as satellites, the current properties are used.
2. Introduce the "apply_fix_mass_swapping_events" flag.
3. + small changes

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new flag to handle mass swapping events and fixes issues related to the properties of satellite subhalos at infall. It also includes enhancements to calculations involving virial radius and specific angular momentum, ensuring they correctly use infall properties when applicable.

- **New Features**:
    - Introduced the 'apply_fix_mass_swapping_events' flag to handle mass swapping events more effectively.
- **Bug Fixes**:
    - Ensured properties at infall have non-zero values for satellite subhalos that aren't born as satellites, using current properties for those that are.
- **Enhancements**:
    - Updated various calculations to use infall properties for satellite subhalos when the 'apply_fix_mass_swapping_events' flag is set.
    - Refined the logic for determining virial radius and specific angular momentum based on subhalo type and infall properties.

<!-- Generated by sourcery-ai[bot]: end summary -->