### PR TITLE
Merger trees artefact treatment: mass swapping and massive transients

### DIFF
--- a/include/dark_matter_halos.h
+++ b/include/dark_matter_halos.h
@@ -70,7 +70,7 @@ public:
 	bool random_lambda = false;
 	bool spin_mass_dependence = false;
 	bool use_converged_lambda_catalog = false; 
-	bool apply_fix_to_mass_swapping_events = false;
+	bool apply_fix_to_mass_swapping_events = true;
 	int  min_part_convergence = 100;
 
 };

--- a/include/execution.h
+++ b/include/execution.h
@@ -95,6 +95,15 @@ public:
         float transient_gainedmass_ratio_low = 0.1;
         // Mass_TDSH/Mass_SH maximum increase value
         float transient_gainedmass_ratio_up = 3;
+
+        // how the transients are defined
+        enum TransientDefinition {
+	        ZDEP_3SIGMA = 0,
+	        CONST_200,
+		CONST_10MINPART
+	};
+
+        TransientDefinition define_transient = ZDEP_3SIGMA;
 };
 
 } // namespace shark

--- a/include/execution.h
+++ b/include/execution.h
@@ -85,6 +85,16 @@ public:
 	float ode_solver_precision = 0;
 	int ignore_npart_threshold = 1000;
 	float ignore_below_z = 1.0;
+
+        // massive transients parameters
+        // flag to apply fixes for them
+        bool apply_fix_to_massive_transient_events = true;
+        // Mass_DSH/Mass_SH minimum decrease value
+        float transient_lostmass_ratio = 0.7;
+        // Mass_TDSH/Mass_SH minimum increase value
+        float transient_gainedmass_ratio_low = 0.0;
+        // Mass_TDSH/Mass_SH maximum increase value
+        float transient_gainedmass_ratio_up = 1.5;
 };
 
 } // namespace shark

--- a/include/execution.h
+++ b/include/execution.h
@@ -98,12 +98,12 @@ public:
 
         // how the transients are defined
         enum TransientDefinition {
-	        CONST_10MINPART = 0,
+	        ZDEP_3SIGMA = 0,
 	        CONST_200,
-	        ZDEP_3SIGMA
+		CONST_10MINPART
 	};
 
-        TransientDefinition define_transient = CONST_10MINPART;
+        TransientDefinition define_transient = ZDEP_3SIGMA;
 };
 
 } // namespace shark

--- a/include/execution.h
+++ b/include/execution.h
@@ -92,9 +92,9 @@ public:
         // Mass_DSH/Mass_SH minimum decrease value
         float transient_lostmass_ratio = 0.7;
         // Mass_TDSH/Mass_SH minimum increase value
-        float transient_gainedmass_ratio_low = 0.0;
+        float transient_gainedmass_ratio_low = 0.1;
         // Mass_TDSH/Mass_SH maximum increase value
-        float transient_gainedmass_ratio_up = 1.5;
+        float transient_gainedmass_ratio_up = 3;
 };
 
 } // namespace shark

--- a/include/execution.h
+++ b/include/execution.h
@@ -98,12 +98,12 @@ public:
 
         // how the transients are defined
         enum TransientDefinition {
-	        ZDEP_3SIGMA = 0,
+	        CONST_10MINPART = 0,
 	        CONST_200,
-		CONST_10MINPART
+	        ZDEP_3SIGMA
 	};
 
-        TransientDefinition define_transient = ZDEP_3SIGMA;
+        TransientDefinition define_transient = CONST_10MINPART;
 };
 
 } // namespace shark

--- a/include/halo.h
+++ b/include/halo.h
@@ -164,6 +164,8 @@ public:
 
         bool hydrostatic_eq = false;
 
+        /// Whether this subhalo is a massive transient.
+        bool transient = false;
 
 };
 

--- a/include/merger_tree_reader.h
+++ b/include/merger_tree_reader.h
@@ -42,8 +42,7 @@ public:
 	 *
 	 * @param trees_dir Directory where all tree files are located
 	 */
-        SURFSReader(const std::string &prefix, DarkMatterHalosPtr dark_matter_halos, SimulationParameters simulation_params, unsigned int threads,
-		    const std::string &transients_prefix);
+        SURFSReader(const std::string &prefix, DarkMatterHalosPtr dark_matter_halos, SimulationParameters simulation_params, unsigned int threads);
 
 	const std::vector<HaloPtr> read_halos(std::vector<unsigned int> batches);
 
@@ -52,12 +51,10 @@ private:
 	DarkMatterHalosPtr dark_matter_halos;
 	SimulationParameters simulation_params;
 	unsigned int threads;
-        std::string transients_prefix;
   
 	const std::vector<HaloPtr> read_halos(unsigned int batch);
 	const std::vector<SubhaloPtr> read_subhalos(unsigned int batch);
 	const std::string get_filename(unsigned int batch);
-        const std::string get_transients_filename(unsigned int batch);
   
 };
 

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -55,8 +55,6 @@ public:
 
 	bool hydrorun = false;
 
-	std::string transients_prefix;
-
 	void load_simulation_tables(const std::string &redshift_file);
 };
 

--- a/include/subhalo.h
+++ b/include/subhalo.h
@@ -287,8 +287,10 @@ public:
 	bool main_progenitor = false;
 	/// Whether this subhalo is the result of an interpolation in snapshots were descendants were missing. In this case Dhalos puts a subhalo in those snapshots  to ensure continuation of the merger tree.
 	bool IsInterpolated = false;
-        /// Whether this subhalo is a massive transients.
-        int transient = 0;
+        /// Whether this subhalo is a massive transient.
+        bool transient = false;
+        /// Whether this transient subhalo has had the main progenitor flag changed.
+        bool remove_mp_flag = false;
   
 private:
 	void do_check_satellite_subhalo_galaxy_composition() const;

--- a/include/subhalo.h
+++ b/include/subhalo.h
@@ -283,10 +283,14 @@ public:
 	subhalo_type_t subhalo_type = CENTRAL;
 	/// Whether this subhalo has a descendant or not
 	bool has_descendant = false;
+	/// Whether this subhalo has a main progenitor or not
+	bool has_mainprogenitor = false;
 	/// Whether this subhalo is a main progenitor of its descendant.
 	bool main_progenitor = false;
 	/// Whether this subhalo is the result of an interpolation in snapshots were descendants were missing. In this case Dhalos puts a subhalo in those snapshots  to ensure continuation of the merger tree.
 	bool IsInterpolated = false;
+        /// Whether this subhalo is a main branch subhalo being born (transient candidate).
+        bool transient_candidate = false;
         /// Whether this subhalo is a massive transient.
         bool transient = false;
         /// Whether this transient subhalo has had the main progenitor flag changed.

--- a/include/tree_builder.h
+++ b/include/tree_builder.h
@@ -54,13 +54,16 @@ protected:
 
 	ExecutionParameters &get_exec_params();
 
-        virtual void loop_through_halos(std::vector<HaloPtr> &halos, ExecutionParameters exec_params) = 0;
+        virtual void loop_through_halos(std::vector<HaloPtr> &halos, SimulationParameters sim_params, ExecutionParameters exec_params) = 0;
+        virtual void flag_massive_transients(std::vector<HaloPtr> &halos, int snapshot, int last_snapshot, int min_part_subhalo,
+					     SimulationParameters sim_params, ExecutionParameters exec_params) = 0;
 
 	void link(const SubhaloPtr &parent_shalo, const SubhaloPtr &desc_subhalo,
 	          const HaloPtr &parent_halo, const HaloPtr &desc_halo);
         void massive_transient_fix(const SubhaloPtr &subhalo, const SubhaloPtr &descendant_subhalo, const HaloPtr &halo, const HaloPtr &descendant_halo,
-				   ExecutionParameters exec_params, int count_transient_central, int count_transient_sat, int count_transient_mp);
-
+				   ExecutionParameters exec_params, int last_snapshot, int &count_transient_central, int &count_transient_sat, int &count_transient_mp);
+        double percentiles(std::vector<int> data, double val);
+  
 private:
 	void ensure_trees_are_self_contained(const std::vector<MergerTreePtr> &trees) const;
 	void ensure_halo_mass_growth(const std::vector<MergerTreePtr> &trees, SimulationParameters &sim_params);
@@ -86,9 +89,11 @@ public:
 	HaloBasedTreeBuilder(ExecutionParameters exec_params, unsigned int threads);
 
 protected:
-        void loop_through_halos(std::vector<HaloPtr> &halos, ExecutionParameters exec_params) override;
+        void loop_through_halos(std::vector<HaloPtr> &halos, SimulationParameters sim_params, ExecutionParameters exec_params) override;
+        void flag_massive_transients(std::vector<HaloPtr> &halos, int snapshot, int last_snapshot, int min_part_subhalo,
+				     SimulationParameters sim_params, ExecutionParameters exec_params) override;
 	SubhaloPtr find_descendant_subhalo(const HaloPtr &halo, const SubhaloPtr &subhalo, const HaloPtr &descendant_halo);
-
+        double percentiles(std::vector<int> data, double val);
 };
 
 }  // namespace shark

--- a/include/tree_builder.h
+++ b/include/tree_builder.h
@@ -54,7 +54,7 @@ protected:
 
 	ExecutionParameters &get_exec_params();
 
-	virtual void loop_through_halos(std::vector<HaloPtr> &halos) = 0;
+        virtual void loop_through_halos(std::vector<HaloPtr> &halos, ExecutionParameters exec_params) = 0;
 
 	void link(const SubhaloPtr &parent_shalo, const SubhaloPtr &desc_subhalo,
 	          const HaloPtr &parent_halo, const HaloPtr &desc_halo);
@@ -84,7 +84,7 @@ public:
 	HaloBasedTreeBuilder(ExecutionParameters exec_params, unsigned int threads);
 
 protected:
-	void loop_through_halos(std::vector<HaloPtr> &halos) override;
+        void loop_through_halos(std::vector<HaloPtr> &halos, ExecutionParameters exec_params) override;
 	SubhaloPtr find_descendant_subhalo(const HaloPtr &halo, const SubhaloPtr &subhalo, const HaloPtr &descendant_halo);
 
 };

--- a/include/tree_builder.h
+++ b/include/tree_builder.h
@@ -58,6 +58,8 @@ protected:
 
 	void link(const SubhaloPtr &parent_shalo, const SubhaloPtr &desc_subhalo,
 	          const HaloPtr &parent_halo, const HaloPtr &desc_halo);
+        void massive_transient_fix(const SubhaloPtr &subhalo, const SubhaloPtr &descendant_subhalo, const HaloPtr &halo, const HaloPtr &descendant_halo,
+				   ExecutionParameters exec_params, int count_transient_central, int count_transient_sat, int count_transient_mp);
 
 private:
 	void ensure_trees_are_self_contained(const std::vector<MergerTreePtr> &trees) const;

--- a/sample_lagos23.cfg
+++ b/sample_lagos23.cfg
@@ -40,6 +40,10 @@ ode_solver_precision = 0.05 #5%
 name_model = my_model
 output_sf_histories = true
 snapshots_sf_histories = 199 185 179 174 164 156 149 142 136 131 113 100 88 79 70 63 57 51
+apply_fix_to_massive_transient_events = true
+transient_lostmass_ratio = 0.7
+transient_gainedmass_ratio_low = 0.1
+transient_gainedmass_ratio_up = 3
 
 [cosmology]
 omega_m = 0.3121

--- a/src/disk_instability.cpp
+++ b/src/disk_instability.cpp
@@ -187,8 +187,6 @@ void DiskInstability::create_starburst(SubhaloPtr &subhalo, Galaxy &galaxy, doub
 
 		// grow the BH only if its mass is already >  0 (so the BH has been seeded).
 		if(galaxy.smbh.mass > 0){
-
-			double delta_mbh = 0;
 			if(subhalo->subhalo_type == Subhalo::SATELLITE && subhalo->Vvir_infall != 0 &&
 					darkmatterparams.apply_fix_to_mass_swapping_events){
 				// at infall for subhalos that become satellite

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -60,6 +60,7 @@ ExecutionParameters::ExecutionParameters(const Options &options)
         options.load("execution.transient_lostmass_ratio", transient_lostmass_ratio);
         options.load("execution.transient_gainedmass_ratio_low", transient_gainedmass_ratio_low);
         options.load("execution.transient_gainedmass_ratio_up", transient_gainedmass_ratio_up);
+        options.load("execution.define_transient", define_transient, true);
 }
 
 bool ExecutionParameters::output_snapshot(int snapshot)
@@ -72,4 +73,23 @@ int ExecutionParameters::last_output_snapshot()
 	return *output_snapshots.rbegin();
 }
 
+template <>                                                                                                                                                                                                 
+ExecutionParameters::TransientDefinition                                                                                                                                                                 
+Options::get<ExecutionParameters::TransientDefinition>(const std::string &name, const std::string &value) const {
+        auto lvalue = lower(value);
+	if (lvalue == "zdep_3sigma") {
+	        return ExecutionParameters::ZDEP_3SIGMA;
+        }
+	else if (lvalue == "const_200") {
+	        return ExecutionParameters::CONST_200;
+        }
+	if (lvalue == "const_10minpart") {
+	        return ExecutionParameters::CONST_10MINPART;
+        }
+
+        std::ostringstream os;
+        os << name << " option value invalid: " << value << ". Supported values are zdep_3sigma, const_200, const_10minpart";
+        throw invalid_option(os.str());
+}
+  
 } // namespace shark

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -77,18 +77,18 @@ template <>
 ExecutionParameters::TransientDefinition                                                                                                                                                                 
 Options::get<ExecutionParameters::TransientDefinition>(const std::string &name, const std::string &value) const {
         auto lvalue = lower(value);
-	if (lvalue == "zdep_3sigma") {
-	        return ExecutionParameters::ZDEP_3SIGMA;
+	if (lvalue == "const_10minpart") {
+	        return ExecutionParameters::CONST_10MINPART;
         }
 	else if (lvalue == "const_200") {
 	        return ExecutionParameters::CONST_200;
         }
-	if (lvalue == "const_10minpart") {
-	        return ExecutionParameters::CONST_10MINPART;
+	else if (lvalue == "zdep_3sigma") {
+	        return ExecutionParameters::ZDEP_3SIGMA;
         }
 
         std::ostringstream os;
-        os << name << " option value invalid: " << value << ". Supported values are zdep_3sigma, const_200, const_10minpart";
+        os << name << " option value invalid: " << value << ". Supported values are const_10minpart, const_200, zdep_3sigma";
         throw invalid_option(os.str());
 }
   

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -73,8 +73,8 @@ int ExecutionParameters::last_output_snapshot()
 	return *output_snapshots.rbegin();
 }
 
-template <>                                                                                                                                                                                                 
-ExecutionParameters::TransientDefinition                                                                                                                                                                 
+template <>
+ExecutionParameters::TransientDefinition
 Options::get<ExecutionParameters::TransientDefinition>(const std::string &name, const std::string &value) const {
         auto lvalue = lower(value);
 	if (lvalue == "zdep_3sigma") {

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -77,18 +77,18 @@ template <>
 ExecutionParameters::TransientDefinition                                                                                                                                                                 
 Options::get<ExecutionParameters::TransientDefinition>(const std::string &name, const std::string &value) const {
         auto lvalue = lower(value);
-	if (lvalue == "const_10minpart") {
-	        return ExecutionParameters::CONST_10MINPART;
+	if (lvalue == "zdep_3sigma") {
+	        return ExecutionParameters::ZDEP_3SIGMA;
         }
 	else if (lvalue == "const_200") {
 	        return ExecutionParameters::CONST_200;
         }
-	else if (lvalue == "zdep_3sigma") {
-	        return ExecutionParameters::ZDEP_3SIGMA;
+	if (lvalue == "const_10minpart") {
+	        return ExecutionParameters::CONST_10MINPART;
         }
 
         std::ostringstream os;
-        os << name << " option value invalid: " << value << ". Supported values are const_10minpart, const_200, zdep_3sigma";
+        os << name << " option value invalid: " << value << ". Supported values are zdep_3sigma, const_200, const_10minpart";
         throw invalid_option(os.str());
 }
   

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -55,6 +55,11 @@ ExecutionParameters::ExecutionParameters(const Options &options)
 
 	options.load("execution.output_bh_histories", output_bh_histories);
 	options.load("execution.snapshots_bh_histories", snapshots_bh_histories);
+
+        options.load("execution.apply_fix_to_massive_transient_events", apply_fix_to_massive_transient_events);
+        options.load("execution.transient_lostmass_ratio", transient_lostmass_ratio);
+        options.load("execution.transient_gainedmass_ratio_low", transient_gainedmass_ratio_low);
+        options.load("execution.transient_gainedmass_ratio_up", transient_gainedmass_ratio_up);
 }
 
 bool ExecutionParameters::output_snapshot(int snapshot)

--- a/src/execution.cpp
+++ b/src/execution.cpp
@@ -60,7 +60,7 @@ ExecutionParameters::ExecutionParameters(const Options &options)
         options.load("execution.transient_lostmass_ratio", transient_lostmass_ratio);
         options.load("execution.transient_gainedmass_ratio_low", transient_gainedmass_ratio_low);
         options.load("execution.transient_gainedmass_ratio_up", transient_gainedmass_ratio_up);
-        options.load("execution.define_transient", define_transient, true);
+        options.load("execution.define_transient", define_transient);
 }
 
 bool ExecutionParameters::output_snapshot(int snapshot)

--- a/src/shark_runner.cpp
+++ b/src/shark_runner.cpp
@@ -274,7 +274,7 @@ void SharkRunner::impl::create_per_thread_objects()
 std::vector<MergerTreePtr> SharkRunner::impl::import_trees()
 {
 	Timer t;
-	SURFSReader reader(simulation_params.tree_files_prefix, dark_matter_halos, simulation_params, threads, simulation_params.transients_prefix);
+	SURFSReader reader(simulation_params.tree_files_prefix, dark_matter_halos, simulation_params, threads);
 	HaloBasedTreeBuilder tree_builder(exec_params, threads);
 	auto halos = reader.read_halos(exec_params.simulation_batches);
 	auto trees = tree_builder.build_trees(halos, simulation_params, gas_cooling_params, dark_matter_halo_params, dark_matter_halos, cosmology, all_baryons);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -51,7 +51,6 @@ SimulationParameters::SimulationParameters(const Options &options)
 	options.load("simulation.tree_files_prefix", tree_files_prefix, true);
 	options.load("simulation.redshift_file",redshift_file, true);
 	options.load("simulation.hydrorun", hydrorun, false);
-	options.load("simulation.transients_prefix", transients_prefix);
 
 	load_simulation_tables(redshift_file);
 

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -571,7 +571,7 @@ void TreeBuilder::define_properties_central_subhalos(const std::vector<MergerTre
 		for(int snapshot=sim_params.max_snapshot; snapshot >= sim_params.min_snapshot; snapshot--) {
 			for(auto &halo: tree->halos_at(snapshot)){
 				// First check if halo has a central subhalo, if yes, then continue with loop.
-				if (halo->central_subhalo) {
+				if (!halo->central_subhalo) {
 					continue;
 				}
 				auto main_prog = halo->central_subhalo->main();

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -215,25 +215,25 @@ SubhaloPtr TreeBuilder::define_central_subhalo(HaloPtr &halo, SubhaloPtr &subhal
 	halo->position = subhalo->position;
 	halo->velocity = subhalo->velocity;
 
-	double mvir = subhalo->Mvir;
-
-	// calculate subhalo properties based on halo mass if number of particles is too small or in the case of applying the fix to mass swapping events:
-	if(dark_matter_params.apply_fix_to_mass_swapping_events){
-		mvir = halo->Mvir;
-	}
-
 	double z = sim_params.redshifts[subhalo->snapshot];
 	double npart = subhalo->Mvir/sim_params.particle_mass;
 
-	subhalo->concentration = darkmatterhalos->nfw_concentration(mvir, z);
-	
-	if (subhalo->concentration < 1) {
-	        throw invalid_argument("concentration is <1, cannot continue. Please check input catalogue");
+	// calculate subhalo properties based on halo mass in the case of applying the fix to mass swapping events:
+	if(dark_matter_params.apply_fix_to_mass_swapping_events){
+
+	        auto mvir = halo->Mvir;
+
+		subhalo->concentration = darkmatterhalos->nfw_concentration(mvir, z);
+		
+		if (subhalo->concentration < 1) {
+		        throw invalid_argument("concentration is <1, cannot continue. Please check input catalogue");
+		}
+		subhalo->lambda = darkmatterhalos->halo_lambda(*subhalo, mvir, z, npart);
+		subhalo->Vvir = darkmatterhalos->halo_virial_velocity(mvir, z);
 	}
-	subhalo->lambda = darkmatterhalos->halo_lambda(*subhalo, mvir, z, npart);
-	subhalo->Vvir = darkmatterhalos->halo_virial_velocity(mvir, z);
 
 	halo->lambda = subhalo->lambda;
+	// Calculate halos' vvir and concentration
 	halo->Vvir = darkmatterhalos->halo_virial_velocity(halo->Mvir, z);
 	halo->concentration = darkmatterhalos->nfw_concentration(halo->Mvir,z);
 

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -1178,7 +1178,7 @@ double HaloBasedTreeBuilder::percentiles(std::vector<int> data, double val){
   // cumulative sum of the weights
   partial_sum(ws.begin(),ws.end(),cumsum.begin());
 
-  for(int i = 0; i < data.size(); i++) {
+  for(std::size_t i = 0; i < data.size(); i++) {
     cumsum[i] = cumsum[i] - 1.*ws[1];
     if(data.size() != 0){
       cumsum[i] = cumsum[i]/(data.size()-1); // value in the x-axis

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -759,7 +759,7 @@ void HaloBasedTreeBuilder::loop_through_halos(std::vector<HaloPtr> &halos, Simul
 					        min_particle_subhalo = particle_subhalo;
 					}
 				}
-			}`
+			}
 		}
 		// minimum particle number for structures
 		if (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART){


### PR DESCRIPTION
1. **Redundancy in define_central_subhalo for mass swapping fix**
Subhalo properties only redefined with the host halo properties for central subhalos when applying mass swapping fixes. Halos vvir and concentration defined with host halo properties and after ensuring their mass growth

2. **Massive transients implementations**
Input file with a list of the **main branch** subhalos that are classified as transients and the halos that host them. When building the trees and making connections subhalo-descendant, if there is a transient in the descendant halo and several constraints are fulfilled, then default subhalo-descendant connection is broken and a subhalo-transient connection has priority. These criteria can be summarized as: 1. transient more massive than descendant, 2. subhalo-descendant connection has a severe mass loss, 3. subhalo-transient connection is smooth enough in terms of the mass. Define parameters used for the massive transients treatment and for computing statistics. Set to true the default flags to apply mass swapping and massive transient fixes.
After playing with the parameters involved in the transient fixes, we set their default values considering mass changes more or less smooth: the mass ratio to break a main progenitor-subhalo link should be <0.7 while the mass ratio to create a new main progenitor-transient link should be in the range 0.1-3.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces fixes for mass swapping in central subhalos and implements a new treatment for massive transients. It includes new parameters for controlling these fixes and enhances the tree building process to prioritize subhalo-transient connections under certain conditions. Additionally, it updates the execution configuration and logging to support these new features.

- **New Features**:
    - Implemented mass swapping fixes for central subhalos, ensuring their properties are redefined with host halo properties.
    - Introduced massive transient treatment, allowing subhalo-transient connections based on specific criteria to improve tree building and connection accuracy.
- **Enhancements**:
    - Added parameters for massive transient treatment, including flags and mass ratio thresholds, to the execution configuration.
    - Updated the tree building process to include statistics for massive transient events, providing detailed logging of the fixes applied.

<!-- Generated by sourcery-ai[bot]: end summary -->