### PR TITLE
Several small fixes

### DIFF
--- a/sample.cfg
+++ b/sample.cfg
@@ -50,6 +50,7 @@ power_spectrum = planck15
 sim_name = mini-SURFS
 volume = 144703.125
 lbox = 210
+particle_mass = 2.21e8 # in Msun/h
 tot_n_subvolumes = 64
 min_snapshot = 51
 max_snapshot = 199

--- a/sample_lagos23.cfg
+++ b/sample_lagos23.cfg
@@ -65,6 +65,7 @@ spin_mass_dependence = true
 sim_name = mini-SURFS
 volume = 144703.125
 lbox = 210
+particle_mass = 2.21e8 # in Msun/h
 tot_n_subvolumes = 64
 min_snapshot = 51
 max_snapshot = 199

--- a/src/evolve_halos.cpp
+++ b/src/evolve_halos.cpp
@@ -117,7 +117,7 @@ void transfer_galaxies_to_next_snapshot(const std::vector<HaloPtr> &halos, int s
 			// Make sure all SFRs and BH accretion rates (in mass and metals) are set to 0 for the next snapshot
 			for (auto &galaxy: subhalo->galaxies) {
 				//restart descendant_id
-				galaxy.descendant_id = -1;
+				//galaxy.descendant_id = -1;
 			}
 
 			// Check if this is a satellite subhalo, and whether this is the last snapshot in which it is identified.

--- a/src/evolve_halos.cpp
+++ b/src/evolve_halos.cpp
@@ -114,12 +114,6 @@ void transfer_galaxies_to_next_snapshot(const std::vector<HaloPtr> &halos, int s
 	for(auto &halo: halos){
 		for(auto &subhalo: halo->all_subhalos()) {
 
-			// Make sure all SFRs and BH accretion rates (in mass and metals) are set to 0 for the next snapshot
-			for (auto &galaxy: subhalo->galaxies) {
-				//restart descendant_id
-				//galaxy.descendant_id = -1;
-			}
-
 			// Check if this is a satellite subhalo, and whether this is the last snapshot in which it is identified.
 			// In that case, the transfer of galaxies has already been done in merging_subhalos.
 			// In any other case, we need to do the transfer.
@@ -207,6 +201,8 @@ void reset_instantaneous_galaxy_properties(const std::vector<HaloPtr> &halos, in
 				galaxy.sfr_disk			= 0;
 				galaxy.smbh.macc_sb		= 0;
 				galaxy.smbh.macc_hh		= 0;
+				//restart descendant_id
+				galaxy.descendant_id            = -1;
 
 				//restart counter of mergers and disk instabilities.
 				galaxy.interaction.restore_interaction_item();

--- a/src/galaxy_mergers.cpp
+++ b/src/galaxy_mergers.cpp
@@ -150,7 +150,7 @@ void GalaxyMergers::merging_timescale(Galaxy &galaxy, SubhaloPtr &primary, Subha
 
 		// The satellites mass including its baryon mass
 		double mgal = galaxy.baryon_mass();
-		double ms = simparams.particle_mass * secondary->Npart + mgal;
+		double ms = secondary->Mvir + mgal;
 		if(transfer_types2){
 			ms = galaxy.msubhalo_type2 + mgal;
 		}

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -750,8 +750,8 @@ void HaloBasedTreeBuilder::loop_through_halos(std::vector<HaloPtr> &halos, Simul
 		for(const auto &halo: halos) {
 			halo_snapshots.insert(halo->snapshot);
 		        // compute the minimum particle number for structures
-			for(const auto &subhalo: halo->all_subhalos()) {
-			        if (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART){
+			if ((exec_params.apply_fix_to_massive_transient_events) && (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART)){
+			        for(const auto &subhalo: halo->all_subhalos()) {
 				        // compute the particle number for each subhalo
 			                particle_subhalo = round(subhalo->Mvir/sim_params.particle_mass);
 					// find the minimum and save it
@@ -762,7 +762,7 @@ void HaloBasedTreeBuilder::loop_through_halos(std::vector<HaloPtr> &halos, Simul
 			}
 		}
 		// minimum particle number for structures
-		if (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART){
+		if ((exec_params.apply_fix_to_massive_transient_events) && (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART)){
 		        LOG(info) << "Minimum particle subhalo: " << min_particle_subhalo;
 		}
 

--- a/src/tree_builder.cpp
+++ b/src/tree_builder.cpp
@@ -749,7 +749,7 @@ void HaloBasedTreeBuilder::loop_through_halos(std::vector<HaloPtr> &halos, Simul
 		std::set<int> halo_snapshots;
 		for(const auto &halo: halos) {
 			halo_snapshots.insert(halo->snapshot);
-		        // compute the minimum particle number for structures
+		        // compute the minimum particle number for structures when the transient fixes are applied
 			if ((exec_params.apply_fix_to_massive_transient_events) && (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART)){
 			        for(const auto &subhalo: halo->all_subhalos()) {
 				        // compute the particle number for each subhalo
@@ -761,7 +761,7 @@ void HaloBasedTreeBuilder::loop_through_halos(std::vector<HaloPtr> &halos, Simul
 				}
 			}
 		}
-		// minimum particle number for structures
+		// minimum particle number for structures when the transient fixes are applied
 		if ((exec_params.apply_fix_to_massive_transient_events) && (exec_params.define_transient == ExecutionParameters::ZDEP_3SIGMA || exec_params.define_transient == ExecutionParameters::CONST_10MINPART)){
 		        LOG(info) << "Minimum particle subhalo: " << min_particle_subhalo;
 		}


### PR DESCRIPTION
1. "descendant_id_galaxy" is restarted after output files are written.
2. Merging timescale in POULTON20 model is computed making use of the virial mass from the merger tree catalogues.
3. "particle_mass" variable is added to the default parameter files.
4. Minimum particle number for subhalos is necessary only when we apply the transient fixes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the galaxy evolution and merger processes by restarting 'descendant_id' after output, using virial mass for merging timescale calculations, and adding 'particle_mass' to configuration files. Adjust the condition for computing minimum particle number for subhalos to only apply when transient fixes are enabled.

Enhancements:
- Restart the 'descendant_id' for galaxies after output files are written to ensure proper initialization for the next snapshot.
- Compute the merging timescale in the POULTON20 model using the virial mass from the merger tree catalogues for more accurate calculations.
- Add 'particle_mass' variable to the default parameter files to provide necessary configuration for simulations.

<!-- Generated by sourcery-ai[bot]: end summary -->