### PR TITLE
Added unit fix to rps stripping

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -514,7 +514,7 @@ double Environment::ram_pressure_stripping_galaxy_gas(const GalaxyPtr &galaxy,
 
 	auto sigma_gas = galaxy->surface_density_gas(r) / 1e12; //In Msun/pc^2
 	auto sigma_gal = (galaxy->surface_density_bulge(r) + galaxy->surface_density_disk(r)) / 1e12; //In Msun/pc^2
-	double func = shark::constants::PI2 *  shark::constants::G * sigma_gas * sigma_gal -
+	double func = shark::constants::PI2 *  shark::constants::G * sigma_gas * sigma_gal * 1e6 -
 			ram_press;
 
 	return func;


### PR DESCRIPTION
This is to fix a unit conversion error when calculating the ISM stripping where there seems to be a missing factor of 10^6 [in _environment.cpp_](https://github.com/ICRAR/shark/blob/4ec413132966d77c1a9c63e546b07d9e115614ff/src/environment.cpp#L517). If surface densities are in Msun/pc^2, then an extra factor of 10^6 comes in when converting Mpc to pc to get the proper unit for pressure (Msun/pc^3 * (km/s)^2).

## Summary by Sourcery

Bug Fixes:
- Fix a unit conversion error in the ISM stripping calculation.