### PR TITLE
Changed the denominator of the RPS equation

### DIFF
--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -493,7 +493,7 @@ double Environment::ram_pressure_stripping_hot_gas(const SubhaloPtr &primary,
 
 	auto enc_mass = darkmatterhalos->enclosed_total_mass(secondary, z, r);
 	double func = parameters.alpha_rps_halo * shark::constants::G * enc_mass *
-			(secondary.hot_halo_gas.mass + secondary.hot_halo_gas_stripped.mass) / (8 * rvir * std::pow(r,3)) / 1e18 -
+			(secondary.hot_halo_gas.mass + secondary.hot_halo_gas_stripped.mass) / (8 * std::pow(rvir,2) * std::pow(r,2)) / 1e18 -
 			ram_press;
 
 	return func;


### PR DESCRIPTION
This is a fix to the RPS equation in [_environment.cpp_](https://github.com/ICRAR/shark/blob/4ec413132966d77c1a9c63e546b07d9e115614ff/src/environment.cpp#L496), where the denominator has been changed from R_virR^3 to R_vir^2R^2 based on the RPS stripping equation of [McCarthy+2008](https://ui.adsabs.harvard.edu/abs/2008MNRAS.383..593M/abstract) and the isothermal hot gas density profile (equation 3 of  [Shark V1](https://ui.adsabs.harvard.edu/abs/2018MNRAS.481.3573L/abstract))

## Summary by Sourcery

Bug Fixes:
- Fixes the denominator of the RPS equation from R_virR^3 to R_vir^2R^2.