### PR TITLE
Rps stripping fix

### DIFF
--- a/include/environment.h
+++ b/include/environment.h
@@ -50,6 +50,7 @@ public:
 	bool tidal_stripping = false;
 	float minimum_halo_mass_fraction = 0.01;
 	float alpha_rps_halo = 1;
+	float alpha_cold = 1;
 	float Accuracy_RPS = 0.05;
 
 };

--- a/sample_lagos23.cfg
+++ b/sample_lagos23.cfg
@@ -157,5 +157,6 @@ stripping = true
 gradual_stripping_halo = true
 gradual_stripping_ism = true
 alpha_rps_halo = 1
+alpha_cold = 1
 tidal_stripping = true
 minimum_halo_mass_fraction = 0.01

--- a/src/dark_matter_halos.cpp
+++ b/src/dark_matter_halos.cpp
@@ -413,7 +413,7 @@ float DarkMatterHalos::enclosed_total_mass(const Subhalo &subhalo, double z, flo
 	auto rnorm = r/rvir;
 
 	//calculate enclosed DM mass
-	auto mdm = mvir * enclosed_mass(rvir, concentration);
+	auto mdm = mvir * enclosed_mass(rnorm, concentration);
 
 	//calculate enclosed hot gas mass (only relevant for isothermal sphere)
 	auto mhot = subhalo.hot_halo_gas.mass * std::pow(rnorm,2);

--- a/src/dark_matter_halos.cpp
+++ b/src/dark_matter_halos.cpp
@@ -416,7 +416,7 @@ float DarkMatterHalos::enclosed_total_mass(const Subhalo &subhalo, double z, flo
 	auto mdm = mvir * enclosed_mass(rnorm, concentration);
 
 	//calculate enclosed hot gas mass (only relevant for isothermal sphere)
-	auto mhot = subhalo.hot_halo_gas.mass * std::pow(rnorm,2);
+	auto mhot = subhalo.hot_halo_gas.mass * std::pow(rnorm,1);
 
 	//calculate enclosed galaxy mass
 	if(galaxy){

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -111,6 +111,11 @@ void Environment::process_satellite_subhalo_environment(Subhalo &satellite_subha
 				auto func_rvir = ram_pressure_stripping_hot_gas(central_subhalo, satellite_subhalo, satellite_subhalo.rvir_infall, z, ram_press);
 				auto func_rvirdiv100 = ram_pressure_stripping_hot_gas(central_subhalo, satellite_subhalo, satellite_subhalo.rvir_infall/100, z, ram_press);
 
+				if(satellite_subhalo.hot_halo_gas_r_rps == 0){
+					// if the hot_halo_gas_r_rps is initialized to 0, instead change it to rvir_infall.
+					satellite_subhalo.hot_halo_gas_r_rps = satellite_subhalo.rvir_infall;
+				}
+				
 				if(func_rvir > 0){
 					r_rps = satellite_subhalo.hot_halo_gas_r_rps;
 				}

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -493,7 +493,7 @@ double Environment::ram_pressure_stripping_hot_gas(const SubhaloPtr &primary,
 
 	auto enc_mass = darkmatterhalos->enclosed_total_mass(secondary, z, r);
 	double func = parameters.alpha_rps_halo * shark::constants::G * enc_mass *
-			(secondary.hot_halo_gas.mass + secondary.hot_halo_gas_stripped.mass) / (8 * std::pow(rvir,2) * std::pow(r,2)) / 1e18 -
+			(secondary.hot_halo_gas.mass + secondary.hot_halo_gas_stripped.mass) / (8 * std::pow(rvir,1) * std::pow(r,3)) / 1e18 -
 			ram_press;
 
 	return func;
@@ -537,7 +537,7 @@ double Environment::ram_pressure(const SubhaloPtr &primary,
 	auto vrel_norm = vrel.norm();
 
 	auto rvir_prim = darkmatterhalos->halo_virial_radius(primary->host_halo->Mvir, z);
-	auto rho_cen = primary->hot_halo_gas.mass / (shark::constants::PI4 * std::pow(rvir_prim,2) * rsat) / 1e18 ; //in Msun/pc^3
+	auto rho_cen = primary->hot_halo_gas.mass / (shark::constants::PI4 * rvir_prim * std::pow(rsat, 2)) / 1e18 ; //in Msun/pc^3
 
 	return rho_cen * std::pow(vrel_norm,2);
 }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -50,6 +50,7 @@ EnvironmentParameters::EnvironmentParameters(const Options &options)
 	options.load("environment.tidal_stripping", tidal_stripping);
 	options.load("environment.minimum_halo_mass_fraction", minimum_halo_mass_fraction);
 	options.load("environment.alpha_rps_halo", alpha_rps_halo);
+	options.load("environment.alpha_cold", alpha_cold);
 
 }
 
@@ -519,7 +520,7 @@ double Environment::ram_pressure_stripping_galaxy_gas(const GalaxyPtr &galaxy,
 
 	auto sigma_gas = galaxy->surface_density_gas(r) / 1e12; //In Msun/pc^2
 	auto sigma_gal = (galaxy->surface_density_bulge(r) + galaxy->surface_density_disk(r)) / 1e12; //In Msun/pc^2
-	double func = shark::constants::PI2 *  shark::constants::G * sigma_gas * sigma_gal * 1e6 -
+	double func = parameters.alpha_cold * shark::constants::PI2 *  shark::constants::G * sigma_gas * sigma_gal * 1e6 -
 			ram_press;
 
 	return func;

--- a/src/galaxy_writer.cpp
+++ b/src/galaxy_writer.cpp
@@ -737,7 +737,7 @@ void HDF5GalaxyWriter::write_galaxies(hdf5::Writer &file, int snapshot, const st
 	file.write_dataset("halo/mvir", halo_m, comment);
 
 	comment = "virial velocity of halo [km/s]";
-	file.write_dataset("halo/vvir", halo_m, comment);
+	file.write_dataset("halo/vvir", halo_v, comment);
 
 	comment = "halo concentration";
 	file.write_dataset("halo/concentration", halo_concentration, comment);


### PR DESCRIPTION
1. Fixed several functions used in the calculation of hot gas RPS, which include: 
- the equation calculating the ram pressure (rho v^2) 
- the binding energy of the hot halo gas 
- the enclosed hot gas mass
- the enclosed dark matter mass
These follow from the assumption of an isothermal density profile of m_hotgas/(4 pi r_vir r^2). 

2. Also have initialized the hot gas stripping radius to be the virial radius at infall, as it was perviously initialized as 0 and no hot gas stripping radii were being calculated. 

3. Added the free parameter `alpha_cold` to govern the strength of cold gas stripping, and set it's default value to be 1.

## Summary by Sourcery

Improve ram pressure stripping (RPS) calculations for hot and cold gas by fixing several computational functions and adding a new parameter to control cold gas stripping strength

New Features:
- Added `alpha_cold` parameter to control the strength of cold gas stripping

Bug Fixes:
- Corrected equations for calculating ram pressure, binding energy, and enclosed mass for hot halo gas
- Fixed initialization of hot gas stripping radius to use virial radius at infall

Enhancements:
- Modified density profile calculations for hot gas mass and dark matter mass
- Updated ram pressure stripping functions to use more accurate mass and radius calculations